### PR TITLE
feat: mcp registry browse/install/test commands

### DIFF
--- a/src/aidev/models.py
+++ b/src/aidev/models.py
@@ -48,6 +48,7 @@ class MCPServerRegistry(BaseModel):
     install: dict[str, str]
     configuration: dict[str, list[str]] = Field(default_factory=dict)
     tags: list[str] = Field(default_factory=list)
+    compatible_profiles: list[str] = Field(default_factory=list)
 
 
 class ProjectConfig(BaseModel):


### PR DESCRIPTION
## Summary
- add MCP CLI commands: `ai mcp list/search/install/remove/test`, with install optionally enabling the server in the active/specified profile
- registry fetch now falls back to cache or bundled examples and respects `AIDEV_MCP_REGISTRY` override; adds compatible_profiles field to registry model
- offline/404 registry now yields cached/fallback entries instead of empty failure
- `mcp test` adds basic connectivity hints; `mcp remove` cleans profiles; README updated; unit tests for registry fallback/install/remove/test

## Testing
- `python -m py_compile src/aidev/cli.py src/aidev/mcp.py src/aidev/models.py tests/unit/test_mcp.py`
- (manual) `ai mcp search filesystem` should work via bundled fallback when offline
