### PR TITLE
Remove Zed editor from supported tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**aidev** is a universal, profile-based configuration manager for AI development tools (Cursor, Claude Code, Zed, Gemini, Codex). It centralizes MCP server configurations, environment variables, and tool launching across different projects and machines.
+**aidev** is a universal, profile-based configuration manager for AI development tools (Cursor, Claude Code, Gemini, Codex). It centralizes MCP server configurations, environment variables, and tool launching across different projects and machines.
 
 ## Development Commands
 
@@ -57,7 +57,7 @@ The codebase is organized around specialized manager classes:
 - **ConfigManager** (`config.py`): Directory initialization, env variable merging (global `~/.aidev/.env` + project `.aidev/.env`), project initialization
 - **ProfileManager** (`profiles.py`): Load/save profiles with inheritance (`extends` field), tag-based recommendation, built-in vs custom profiles
 - **MCPManager** (`mcp.py`): MCP registry fetching (with cache + offline fallback), server installation/removal, connectivity testing
-- **MCPConfigGenerator** (`mcp_config_generator.py`): Renders tool-specific MCP configs (Cursor, Claude, Codex, Gemini, Zed) from profile definitions
+- **MCPConfigGenerator** (`mcp_config_generator.py`): Renders tool-specific MCP configs (Cursor, Claude, Codex, Gemini) from profile definitions
 - **ToolManager** (`tools.py`): AI tool detection, config path resolution, tool launching with environment injection
 - **QuickstartRunner** (`quickstart.py`): Stack detection (JS/Python/Docker/K8s), profile recommendation based on tags
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A universal, profile-based configuration manager for AI development tools that m
 
 ## Why aidev?
 
-Managing AI development tools (Cursor, Claude Code, Zed) across different projects and machines is painful:
+Managing AI development tools (Cursor, Claude Code, Codex, Gemini) across different projects and machines is painful:
 - 🔐 API keys and credentials scattered everywhere
 - 🔧 Different MCP server configurations per project
 - 💻 Tedious setup on new machines
@@ -116,7 +116,6 @@ Launch AI tools with automatic configuration injection:
 ai cursor                       # Launch Cursor
 ai cursor --profile infra      # Launch with infra profile
 ai claude                       # Launch Claude Code
-ai zed                          # Launch Zed
 ai gemini                       # Launch Gemini Code Assist
 ai codex                        # Launch Codex CLI
 ai tool <name>                  # Launch any registered tool
@@ -130,7 +129,7 @@ The aidev CLI is composed of modular managers:
 - `config.py`: directories, env, project initialization (global + project scope merge)
 - `profiles.py`: built-in/custom profiles, tagging, inheritance, persistence
 - `mcp.py`: MCP registry, install/remove/test with cache/fallback handling
-- `mcp_config_generator.py`: renders MCP config for tools (Cursor, Claude, Codex, Gemini, Zed)
+- `mcp_config_generator.py`: renders MCP config for tools (Cursor, Claude, Codex, Gemini)
 - `errors.py`: centralized preflight checks and actionable guidance
 - `tui_config.py`: Textual TUI for profile/env editing
 
@@ -225,7 +224,8 @@ aidev mcp test NAME                # Test connectivity
 ```bash
 aidev cursor [--profile NAME]      # Launch Cursor
 aidev claude [--profile NAME]      # Launch Claude Code
-aidev zed [--profile NAME]         # Launch Zed
+aidev codex [--profile NAME]       # Launch Codex CLI
+aidev gemini [--profile NAME]      # Launch Gemini Code Assist
 aidev tool NAME [--profile NAME]   # Launch any tool
 ```
 

--- a/configs/supported-tools.json
+++ b/configs/supported-tools.json
@@ -26,12 +26,5 @@
     "app_name": "Gemini",
     "config_path": "~/.gemini/settings.json",
     "install_url": "https://ai.google.dev/gemini-api"
-  },
-  "zed": {
-    "name": "Zed",
-    "binary": "zed",
-    "app_name": "Zed",
-    "config_path": "~/.config/zed/mcp.json",
-    "install_url": "https://zed.dev"
   }
 }

--- a/docs/TOOL_LAUNCHING.md
+++ b/docs/TOOL_LAUNCHING.md
@@ -57,7 +57,7 @@ Different launch methods for different tool types:
 if is_interactive_cli:
     os.execvp(tool_info.binary, cmd)  # Replace process, stay attached to terminal
 
-# GUI apps (Cursor, Zed)
+# GUI apps (Cursor)
 else:
     subprocess.Popen(cmd, start_new_session=True)  # Background launch
 ```
@@ -158,7 +158,6 @@ ai claude --profile researcher
 
 ### GUI Applications
 - **Cursor**: GUI editor
-- **Zed**: GUI editor
 - **Launch method**: `subprocess.Popen(..., start_new_session=True)`
 - **Directory**: Passed as argument (e.g., `cursor .`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 - **Config Manager (`config.py`)**: Initializes directories, merges global + project env, handles project init and tool config scaffolding.
 - **Profiles (`profiles.py`)**: Built-in/custom profiles with tags and inheritance; save/load/merge utilities.
 - **MCP (`mcp.py`)**: Registry fetch (with cache + bundled fallback), install/remove, connectivity testing, server config storage.
-- **MCP Config Generator (`mcp_config_generator.py`)**: Emits MCP configs for tools (Cursor, Claude, Codex, Gemini, Zed) from profiles.
+- **MCP Config Generator (`mcp_config_generator.py`)**: Emits MCP configs for tools (Cursor, Claude, Codex, Gemini) from profiles.
 - **Errors/Preflight (`errors.py`)**: Centralized env/binary checks with actionable hints; used by `ai doctor`.
 - **TUI (`tui_config.py`)**: Textual-based profile/env editor, loads project/active defaults.
 

--- a/src/aidev/cli.py
+++ b/src/aidev/cli.py
@@ -37,7 +37,7 @@ def _launch_tool_with_profile(tool_id: str, profile: str, args: tuple) -> None:
     Launch a tool with the specified profile and MCP configuration
 
     Args:
-        tool_id: Tool identifier (cursor, claude, zed)
+        tool_id: Tool identifier (cursor, claude, codex, gemini)
         profile: Profile name to use (or None for default)
         args: Additional arguments to pass to the tool
     """
@@ -85,7 +85,7 @@ def cli() -> None:
     aidev - Universal AI development environment manager
 
     Manage AI tool configurations, profiles, and MCP servers across
-    Cursor, Claude Code, Zed, and other AI-powered development tools.
+    Cursor, Claude Code, Codex, Gemini, and other AI-powered development tools.
     """
     pass
 
@@ -349,14 +349,6 @@ def codex(profile: str, args: tuple) -> None:
 def gemini(profile: str, args: tuple) -> None:
     """Launch Gemini Code Assist with aidev configuration"""
     _launch_tool_with_profile("gemini", profile, args)
-
-
-@cli.command()
-@click.option("--profile", help="Profile to use")
-@click.argument("args", nargs=-1)
-def zed(profile: str, args: tuple) -> None:
-    """Launch Zed with aidev configuration"""
-    _launch_tool_with_profile("zed", profile, args)
 
 
 @cli.command()

--- a/src/aidev/mcp_config_generator.py
+++ b/src/aidev/mcp_config_generator.py
@@ -156,7 +156,7 @@ class MCPConfigGenerator:
         return servers, disabled
 
     def _write_standard_config(self, config_path: Path, servers: dict[str, dict]) -> None:
-        """Write legacy JSON configs used by Cursor/Claude/Zed/etc."""
+        """Write legacy JSON configs used by Cursor/Claude/etc."""
         ensure_dir(config_path.parent)
         config = {"mcpServers": servers}
         with open(config_path, "w") as f:


### PR DESCRIPTION
Addresses #11 by removing Zed from the project scope.

Changes:
- Removed Zed from configs/supported-tools.json
- Removed 'ai zed' CLI command from cli.py
- Updated documentation to remove Zed references
- Updated comments in mcp_config_generator.py
- Simplified tool lists in README and CLAUDE.md

Rationale: Zed is not widely adopted enough to justify inclusion in the supported tools list. Users can still manually configure Zed if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)