### PR TITLE
Implement profile diff command (#29)

### DIFF
--- a/src/aidev/cli.py
+++ b/src/aidev/cli.py
@@ -513,6 +513,90 @@ def profile_clone(source: str, target: str, description: str, mcp_servers: str) 
         console.print(f"  • Use:  [cyan]ai use {target}[/cyan]")
 
 
+@profile.command(name="diff")
+@click.argument("profile1")
+@click.argument("profile2")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+def profile_diff(profile1: str, profile2: str, json_output: bool) -> None:
+    """Compare two profiles and show differences
+
+    \b
+    Examples:
+      # Compare web and infra profiles
+      ai profile diff web infra
+
+      # Output as JSON for scripting
+      ai profile diff web infra --json
+    """
+    import json as json_module
+    from rich.panel import Panel
+
+    # Get differences
+    diff = profile_manager.diff_profiles(profile1, profile2)
+    if not diff:
+        return
+
+    # JSON output
+    if json_output:
+        console.print(json_module.dumps(diff, indent=2))
+        return
+
+    # Human-readable output
+    console.print(f"\n[bold]Comparing:[/bold] [cyan]{profile1}[/cyan] → [cyan]{profile2}[/cyan]\n")
+
+    # MCP Servers diff
+    console.print("[bold]MCP Servers:[/bold]")
+    mcp = diff["mcp_servers"]
+    if mcp["added"]:
+        for server in mcp["added"]:
+            console.print(f"  [green]+[/green] {server} (added in {profile2})")
+    if mcp["removed"]:
+        for server in mcp["removed"]:
+            console.print(f"  [red]-[/red] {server} (only in {profile1})")
+    if mcp["common"]:
+        for server in mcp["common"]:
+            console.print(f"  [dim]=[/dim] {server} (common)")
+    if not mcp["added"] and not mcp["removed"] and not mcp["common"]:
+        console.print("  [dim](no MCP servers configured)[/dim]")
+
+    # Environment variables diff
+    console.print(f"\n[bold]Environment Variables:[/bold]")
+    env = diff["environment"]
+    if env["added"]:
+        for var in env["added"]:
+            console.print(f"  [green]+[/green] {var} (added in {profile2})")
+    if env["removed"]:
+        for var in env["removed"]:
+            console.print(f"  [red]-[/red] {var} (only in {profile1})")
+    if env["changed"]:
+        for var, values in env["changed"].items():
+            console.print(
+                f"  [yellow]±[/yellow] {var}: [dim]{values['from']}[/dim] → {values['to']}"
+            )
+    if env["common"] and not env["changed"]:
+        for var in env["common"]:
+            console.print(f"  [dim]=[/dim] {var} (common, same value)")
+    if not env["added"] and not env["removed"] and not env["changed"] and not env["common"]:
+        console.print("  [dim](no environment variables)[/dim]")
+
+    # Tags diff
+    console.print(f"\n[bold]Tags:[/bold]")
+    tags = diff["tags"]
+    if tags["added"]:
+        for tag in tags["added"]:
+            console.print(f"  [green]+[/green] {tag}")
+    if tags["removed"]:
+        for tag in tags["removed"]:
+            console.print(f"  [red]-[/red] {tag}")
+    if tags["common"]:
+        for tag in tags["common"]:
+            console.print(f"  [dim]=[/dim] {tag}")
+    if not tags["added"] and not tags["removed"] and not tags["common"]:
+        console.print("  [dim](no tags)[/dim]")
+
+    console.print()
+
+
 @profile.command(name="edit")
 @click.argument("name")
 def profile_edit(name: str) -> None:


### PR DESCRIPTION
## Summary

Implements profile comparison functionality to visualize differences between two profiles.

Part of **Phase 1** quick wins - provides transparency and debugging tools for understanding profile configurations.

## Features Added

- ✅ Compare MCP servers (added/removed/common)
- ✅ Compare environment variables (added/removed/changed/common)
- ✅ Compare tags
- ✅ Color-coded output:
  - `+` green for additions
  - `-` red for removals
  - `=` dim for common items
  - `±` yellow for changed values
- ✅ JSON output option for scripting/automation
- ✅ Fully resolves profile inheritance before comparison

## Usage Examples

### Human-readable diff
```bash
# Compare web and infra profiles
ai profile diff web infra

# Output:
Comparing: web → infra

MCP Servers:
  + atlassian (added in infra)
  + gitlab (added in infra)
  + k8s (added in infra)
  - github (only in web)
  - memory-bank (only in web)
  = filesystem (common)
  = git (common)

Environment Variables:
  + KUBECONFIG (added in infra)

Tags:
  + infra
  - web
```

### JSON output for scripting
```bash
ai profile diff web qa --json
```

## Implementation Details

**ProfileManager.diff_profiles()** (`src/aidev/profiles.py`)
- Loads both profiles (fully resolved with inheritance)
- Compares MCP servers using set operations
- Detects added/removed/changed environment variables
- Compares tags
- Returns structured dictionary

**CLI Command** (`src/aidev/cli.py`)
- Added `ai profile diff` command
- Two output modes: human-readable (color-coded) and JSON
- Shows differences in MCP servers, environment variables, and tags

## Benefits

- **Debugging**: Quickly see why profiles behave differently
- **Learning**: Understand what each profile provides
- **Automation**: JSON output for CI/CD scripts

## Test Plan

- [x] Compare built-in profiles
- [x] JSON output format is valid
- [x] Handles profiles with inheritance
- [x] Shows changed environment variable values
- [x] Color coding works

## Files Changed

- `src/aidev/profiles.py` - Added `diff_profiles()` method (66 lines)
- `src/aidev/cli.py` - Added `profile diff` command (84 lines)

Closes #29