### PR TITLE
Implement profile templates feature (#25)

### DIFF
--- a/src/aidev/cli.py
+++ b/src/aidev/cli.py
@@ -674,6 +674,71 @@ def profile_import(file: str) -> None:
     console.print(f"[green]✓[/green] Imported profile from {file}")
 
 
+@profile.command(name="templates")
+@click.argument("template_name", required=False)
+@click.argument("profile_name", required=False)
+def profile_templates(template_name: str, profile_name: str) -> None:
+    """Browse and create profiles from pre-built templates
+
+    \b
+    Examples:
+      # List all templates
+      ai profile templates
+
+      # Create profile from template
+      ai profile templates nextjs-fullstack my-project
+      ai profile templates django-api backend-api
+    """
+    # If no arguments, list all templates
+    if not template_name:
+        templates = profile_manager.get_profile_templates()
+
+        table = Table(title="Profile Templates", show_header=True)
+        table.add_column("Template", style="cyan")
+        table.add_column("Description", style="white")
+        table.add_column("Base", style="yellow")
+        table.add_column("Tags", style="dim")
+
+        for template in templates:
+            tags = ", ".join(template["tags"][:3])  # Show first 3 tags
+            if len(template["tags"]) > 3:
+                tags += "..."
+            table.add_row(
+                template["name"],
+                template["description"],
+                template["base"],
+                tags,
+            )
+
+        console.print(table)
+        console.print("\n[bold]Usage:[/bold]")
+        console.print("  ai profile templates <template-name> <new-profile-name>")
+        console.print("\n[bold]Example:[/bold]")
+        console.print("  ai profile templates nextjs-fullstack my-project")
+        return
+
+    # Create profile from template
+    if not profile_name:
+        console.print("[red]Error: Please provide a profile name[/red]")
+        console.print("Usage: ai profile templates <template-name> <new-profile-name>")
+        return
+
+    created = profile_manager.create_from_template(template_name, profile_name)
+
+    if created:
+        # Show what was created
+        console.print(f"\n[bold]Created Profile:[/bold] [cyan]{profile_name}[/cyan]")
+        console.print(f"[dim]Template:[/dim] {template_name}")
+        console.print(f"[dim]Description:[/dim] {created.description}")
+        console.print(f"[dim]MCP Servers:[/dim] {len(created.mcp_servers)} configured")
+
+        # Suggest next steps
+        console.print(f"\n[bold]Next steps:[/bold]")
+        console.print(f"  • View:  [cyan]ai profile show {profile_name}[/cyan]")
+        console.print(f"  • Edit:  [cyan]ai config[/cyan] (then select '{profile_name}')")
+        console.print(f"  • Use:   [cyan]ai use {profile_name}[/cyan]")
+
+
 # ============================================================================
 # MCP Server Management Commands
 # ============================================================================

--- a/src/aidev/profiles.py
+++ b/src/aidev/profiles.py
@@ -424,3 +424,104 @@ class ProfileManager:
                 extends="web",
             ),
         ]
+
+    def get_profile_templates(self) -> list[dict]:
+        """
+        Get pre-built profile templates for common tech stacks
+
+        Returns:
+            List of template dictionaries with name, description, base, and servers
+        """
+        return [
+            {
+                "name": "nextjs-fullstack",
+                "description": "Next.js + PostgreSQL + Redis full-stack app",
+                "base": "web",
+                "mcp_servers": ["filesystem", "git", "github", "postgres", "redis", "memory-bank"],
+                "tags": ["web", "javascript", "typescript", "nextjs", "database"],
+            },
+            {
+                "name": "django-api",
+                "description": "Django REST API + PostgreSQL + Redis",
+                "base": "web",
+                "mcp_servers": ["filesystem", "git", "github", "postgres", "redis", "memory-bank"],
+                "tags": ["web", "python", "django", "api", "database"],
+            },
+            {
+                "name": "react-native",
+                "description": "React Native mobile app development",
+                "base": "web",
+                "mcp_servers": ["filesystem", "git", "github", "memory-bank"],
+                "tags": ["mobile", "javascript", "typescript", "react"],
+            },
+            {
+                "name": "microservices",
+                "description": "Microservices with Docker + Kubernetes",
+                "base": "infra",
+                "mcp_servers": ["filesystem", "git", "github", "docker", "k8s", "memory-bank"],
+                "tags": ["infra", "docker", "kubernetes", "microservices"],
+            },
+            {
+                "name": "data-science",
+                "description": "Data science and ML workflows",
+                "base": "web",
+                "mcp_servers": ["filesystem", "git", "github", "postgres", "memory-bank"],
+                "tags": ["data", "python", "ml", "jupyter"],
+            },
+            {
+                "name": "monorepo",
+                "description": "Monorepo with Turborepo/Nx + multiple services",
+                "base": "web",
+                "mcp_servers": ["filesystem", "git", "github", "postgres", "redis", "memory-bank"],
+                "tags": ["web", "monorepo", "turborepo", "nx"],
+            },
+        ]
+
+    def create_from_template(self, template_name: str, profile_name: str) -> Optional[Profile]:
+        """
+        Create a new profile from a template
+
+        Args:
+            template_name: Template to use
+            profile_name: Name for the new profile
+
+        Returns:
+            Created profile or None if template not found
+        """
+        # Check if profile already exists
+        if self.get_profile_path(profile_name):
+            console.print(f"[red]Profile '{profile_name}' already exists[/red]")
+            return None
+
+        # Find template
+        templates = self.get_profile_templates()
+        template = next((t for t in templates if t["name"] == template_name), None)
+
+        if not template:
+            console.print(f"[red]Template '{template_name}' not found[/red]")
+            return None
+
+        # Create profile from template
+        profile_data = {
+            "name": profile_name,
+            "description": f"{template['description']} (from template: {template_name})",
+            "extends": template["base"],
+            "tags": template["tags"],
+            "mcp_servers": [
+                MCPServerConfig(name=server, enabled=True)
+                for server in template["mcp_servers"]
+            ],
+            "environment": {},
+            "tools": {},
+        }
+
+        try:
+            profile = Profile(**profile_data)
+            self.save_profile(profile, custom=True)
+            console.print(
+                f"[green]✓[/green] Created profile '[cyan]{profile_name}[/cyan]' from template '[cyan]{template_name}[/cyan]'"
+            )
+            return profile
+        except Exception as e:
+            console.print(f"[red]Error creating profile from template: {e}[/red]")
+            return None


### PR DESCRIPTION
## Summary

Adds a profile templates system that provides pre-built profiles for common tech stacks. Users can browse templates and quickly create customized profiles from them.

## Features Added

### 6 Pre-Built Templates:
- **nextjs-fullstack**: Next.js + PostgreSQL + Redis full-stack app
- **django-api**: Django REST API + PostgreSQL + Redis
- **react-native**: React Native mobile development
- **microservices**: Docker + Kubernetes microservices
- **data-science**: Data science and ML workflows
- **monorepo**: Turborepo/Nx monorepo setup

### Commands:
```bash
# List all templates
ai profile templates

# Create profile from template
ai profile templates nextjs-fullstack my-project
ai profile templates django-api backend-api
```

## Implementation

- Added `get_profile_templates()` to ProfileManager - returns template definitions
- Added `create_from_template()` to ProfileManager - creates profile from template
- Added `ai profile templates` CLI command with:
  - Table display of all templates with description, base, and tags
  - Create profile from template with auto-save to custom profiles
  - Helpful next-steps guidance after creation

## Testing

```bash
# List templates
$ ai profile templates
# Shows table with 6 templates

# Create from template
$ ai profile templates nextjs-fullstack my-nextjs
✓ Created profile 'my-nextjs' from template 'nextjs-fullstack'

# Verify
$ ai profile show my-nextjs
# Shows 6 MCP servers: filesystem, git, github, memory-bank, postgres, redis
```

## Benefits

- **Faster onboarding**: Get started with common stacks in seconds
- **Best practices**: Templates encode recommended MCP server setups
- **Customizable**: Created profiles are fully editable custom profiles
- **Discoverable**: Table view shows what's available with descriptions

Closes #25