### PR TITLE
Add MCP browser TUI and install fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Discover, install, and manage MCP servers:
 ai mcp search kubernetes
 # ⭐ kubernetes - Manage K8s clusters and deployments
 
+# Browse registry in a TUI
+ai mcp browse
+# Filter by tags, view details, and install directly
+
 # Install and auto-configure
 ai mcp install kubernetes
 # ✓ Installed kubernetes

--- a/src/aidev/cli.py
+++ b/src/aidev/cli.py
@@ -925,6 +925,19 @@ def mcp_search(query: str, refresh: bool) -> None:
     console.print(table)
 
 
+@mcp.command(name="browse")
+@click.option("--refresh", is_flag=True, help="Refresh registry cache before launching")
+def mcp_browse(refresh: bool) -> None:
+    """Launch a TUI to browse and install MCP servers."""
+    try:
+        from aidev.tui_mcp_browser import MCPBrowserApp
+    except Exception as exc:  # pragma: no cover - defensive
+        console.print(f"[red]Failed to launch MCP browser: {exc}[/red]")
+        return
+    app = MCPBrowserApp(mcp_manager=mcp_manager, refresh_on_start=refresh)
+    app.run()
+
+
 @mcp.command(name="install")
 @click.argument("name")
 @click.option("--profile", help="Profile to enable this server in")

--- a/src/aidev/tui_mcp_browser.py
+++ b/src/aidev/tui_mcp_browser.py
@@ -1,0 +1,212 @@
+"""
+Textual TUI for browsing the MCP registry.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable, Optional
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Horizontal, Vertical
+from textual.widgets import Button, DataTable, Footer, Header, Input, Markdown, Static
+
+from aidev.mcp import MCPManager
+from aidev.models import MCPServerRegistry
+
+
+def filter_registry_entries(
+    entries: Iterable[MCPServerRegistry], query: str = "", tag: Optional[str] = None
+) -> list[MCPServerRegistry]:
+    """Filter registry entries by query and optional tag."""
+    query_lower = (query or "").strip().lower()
+    tag_lower = tag.lower() if tag else None
+
+    filtered: list[MCPServerRegistry] = []
+    for entry in entries:
+        if tag_lower and tag_lower not in {t.lower() for t in entry.tags}:
+            continue
+
+        if query_lower:
+            haystacks = [
+                entry.name.lower(),
+                entry.description.lower(),
+                entry.author.lower(),
+                " ".join(entry.tags).lower(),
+            ]
+            if not any(query_lower in h for h in haystacks):
+                continue
+
+        filtered.append(entry)
+
+    return sorted(filtered, key=lambda e: e.name.lower())
+
+
+class MCPBrowserApp(App):
+    """TUI for browsing, filtering, and installing MCP servers."""
+
+    CSS_PATH = None
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("/", "focus_search", "Search"),
+        Binding("r", "refresh_registry", "Refresh"),
+        Binding("i", "install_selected", "Install"),
+    ]
+
+    def __init__(self, mcp_manager: Optional[MCPManager] = None, refresh_on_start: bool = False) -> None:
+        super().__init__()
+        self.mcp_manager = mcp_manager or MCPManager()
+        self.registry: list[MCPServerRegistry] = []
+        self.filtered: list[MCPServerRegistry] = []
+        self.installed: set[str] = set()
+        self.selected_tag: Optional[str] = None
+        self.refresh_on_start = refresh_on_start
+
+    def compose(self) -> ComposeResult:
+        """Build layout."""
+        yield Header(show_clock=False)
+        yield Footer()
+        with Container():
+            with Horizontal(id="filters"):
+                yield Input(placeholder="Search (/, Enter)", id="search")
+                yield DataTable(id="tag-table", zebra_stripes=True)
+                yield Button("Refresh", id="refresh-btn", variant="default")
+            with Horizontal():
+                with Vertical(id="left"):
+                    table = DataTable(id="registry-table", zebra_stripes=True)
+                    table.add_columns("Name", "Version", "Tags", "Status")
+                    yield table
+                with Vertical(id="right"):
+                    yield Static("Details", classes="panel-title")
+                    yield Markdown("", id="details")
+                    yield Button("Install (i)", id="install-btn", variant="primary")
+                    yield Static("", id="status")
+
+    async def on_mount(self) -> None:
+        """Load registry and focus search."""
+        await self._refresh_registry(force=self.refresh_on_start)
+        self.query_one("#search", Input).focus()
+
+    async def _refresh_registry(self, force: bool = False) -> None:
+        """Fetch registry and populate UI."""
+        status = self.query_one("#status", Static)
+        status.update("Loading registry...")
+        try:
+            entries = await asyncio.to_thread(self.mcp_manager.fetch_registry, force)
+            self.registry = entries
+            self.installed = set(self.mcp_manager.list_installed())
+            self._populate_tags()
+            self._apply_filters()
+            status.update(f"Loaded {len(entries)} servers")
+        except Exception as exc:  # pragma: no cover - defensive
+            status.update(f"[red]Failed to load registry: {exc}[/red]")
+
+    def _populate_tags(self) -> None:
+        """Populate tag table from registry entries."""
+        table = self.query_one("#tag-table", DataTable)
+        table.clear()
+        table.add_column("Tags")
+        table.add_row("All", key="__all__")
+        tags = sorted({tag for entry in self.registry for tag in entry.tags})
+        for tag in tags:
+            table.add_row(tag, key=tag)
+        table.cursor_coordinate = (0, 0)
+        self.selected_tag = None
+
+    def _apply_filters(self) -> None:
+        """Apply search/tag filters to registry list."""
+        search_value = self.query_one("#search", Input).value or ""
+        active_tag = None if not self.selected_tag or self.selected_tag == "__all__" else self.selected_tag
+        self.filtered = filter_registry_entries(self.registry, search_value, active_tag)
+
+        table = self.query_one("#registry-table", DataTable)
+        table.clear()
+        for entry in self.filtered:
+            tags = ", ".join(entry.tags) if entry.tags else "-"
+            status = "installed" if entry.name in self.installed else ""
+            table.add_row(entry.name, entry.version, tags, status, key=entry.name)
+
+        if table.row_count:
+            table.cursor_coordinate = (0, 0)
+            self._update_details(self.filtered[0])
+        else:
+            self.query_one("#details", Markdown).update("No results.")
+
+    def _current_entry(self) -> Optional[MCPServerRegistry]:
+        """Get the currently highlighted entry."""
+        table = self.query_one("#registry-table", DataTable)
+        if table.cursor_coordinate is None or not self.filtered:
+            return None
+        row, _ = table.cursor_coordinate
+        if 0 <= row < len(self.filtered):
+            return self.filtered[row]
+        return None
+
+    def _update_details(self, entry: MCPServerRegistry) -> None:
+        """Render details for the selected entry."""
+        tags = ", ".join(entry.tags) if entry.tags else "-"
+        profiles = ", ".join(entry.compatible_profiles) if entry.compatible_profiles else "-"
+        install_cmd = entry.install.get("command", "")
+        repo = entry.repository or "-"
+        body = (
+            f"### {entry.name}\n\n"
+            f"{entry.description}\n\n"
+            f"- **Author:** {entry.author}\n"
+            f"- **Version:** {entry.version}\n"
+            f"- **Tags:** {tags}\n"
+            f"- **Profiles:** {profiles or '-'}\n"
+            f"- **Repository:** {repo}\n"
+            f"- **Install:** `{install_cmd}`\n"
+        )
+        self.query_one("#details", Markdown).update(body)
+
+    async def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """Update details when selection changes."""
+        if event.table.id == "registry-table":
+            entry = self._current_entry()
+            if entry:
+                self._update_details(entry)
+        elif event.table.id == "tag-table":
+            self.selected_tag = event.row_key if event.row_key != "__all__" else None
+            self._apply_filters()
+
+    async def on_input_changed(self, event: Input.Changed) -> None:
+        """Live filter as search input changes."""
+        if event.input.id == "search":
+            self._apply_filters()
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Button handlers."""
+        if event.button.id == "refresh-btn":
+            await self._refresh_registry(force=True)
+        elif event.button.id == "install-btn":
+            await self.action_install_selected()
+
+    async def action_focus_search(self) -> None:
+        """Focus search input."""
+        self.query_one("#search", Input).focus()
+
+    async def action_refresh_registry(self) -> None:
+        """Refresh registry data."""
+        await self._refresh_registry(force=True)
+
+    async def action_install_selected(self) -> None:
+        """Install the currently selected server."""
+        entry = self._current_entry()
+        status = self.query_one("#status", Static)
+        if not entry:
+            status.update("[yellow]No server selected[/yellow]")
+            return
+
+        status.update(f"Installing {entry.name}...")
+        ok, stdout, stderr = await asyncio.to_thread(self.mcp_manager.install_server, entry.name, return_output=True)
+        if ok:
+            self.installed.add(entry.name)
+            status.update(f"[green]✓ Installed {entry.name}[/green]")
+            self._apply_filters()
+        else:
+            error_msg = stderr.strip() or stdout.strip() or "Unknown error"
+            # Truncate to keep UI tidy
+            if len(error_msg) > 160:
+                error_msg = error_msg[:157] + "..."
+            status.update(f"[red]Failed to install {entry.name}: {error_msg}[/red]")

--- a/tests/unit/test_mcp_browser_filters.py
+++ b/tests/unit/test_mcp_browser_filters.py
@@ -1,0 +1,44 @@
+from aidev.models import MCPServerRegistry
+from aidev.tui_mcp_browser import filter_registry_entries
+
+
+def make_entry(name: str, tags: list[str], description: str = "", author: str = "dev") -> MCPServerRegistry:
+    return MCPServerRegistry(
+        name=name,
+        description=description or name,
+        author=author,
+        repository="https://example.com",
+        version="1.0.0",
+        install={"type": "npm", "command": f"npm install -g {name}"},
+        configuration={},
+        tags=tags,
+        compatible_profiles=[],
+    )
+
+
+def test_filter_by_query_matches_name_and_description():
+    entries = [
+        make_entry("redis", tags=["db"], description="In-memory cache"),
+        make_entry("k8s", tags=["infra"], description="Kubernetes manager"),
+    ]
+    filtered = filter_registry_entries(entries, query="kube")
+    assert [e.name for e in filtered] == ["k8s"]
+
+
+def test_filter_by_tag_and_query():
+    entries = [
+        make_entry("stripe", tags=["payments", "http"]),
+        make_entry("paypal", tags=["payments"]),
+        make_entry("github", tags=["devtools"]),
+    ]
+    filtered = filter_registry_entries(entries, query="pay", tag="payments")
+    assert {e.name for e in filtered} == {"paypal", "stripe"}
+
+
+def test_filter_tag_excludes_non_matching():
+    entries = [
+        make_entry("logger", tags=["tools"]),
+        make_entry("docker", tags=["infra"]),
+    ]
+    filtered = filter_registry_entries(entries, query="", tag="infra")
+    assert [e.name for e in filtered] == ["docker"]


### PR DESCRIPTION
## Summary
- add `ai mcp browse` Textual TUI to search/filter the MCP registry, view details, and install directly
- surface install errors in the TUI; add cargo `--git` fallback when crates.io install fails
- document the new command and add unit tests for registry filtering

## Testing
- `pytest tests/unit/test_mcp_browser_filters.py`
- manual: `ai mcp browse` (verified search/filter/detail panes; observed error surfacing for broken k8s entry)

## Notes
- Registry entry `k8s` is currently broken (crates.io package missing and git fetch fails). Tracked in issue #41. The TUI now surfaces these errors instead of failing silently.
